### PR TITLE
去掉空格有利于css 操作【兼容ie6】。

### DIFF
--- a/Extend/Library/ORG/Util/Page.class.php
+++ b/Extend/Library/ORG/Util/Page.class.php
@@ -134,13 +134,13 @@ class Page {
             $page       =   ($nowCoolPage-1)*$this->rollPage+$i;
             if($page!=$this->nowPage){
                 if($page<=$this->totalPages){
-                    $linkPage .= "&nbsp;<a href='".str_replace('__PAGE__',$page,$url)."'>&nbsp;".$page."&nbsp;</a>";
+                    $linkPage .= "<a href='".str_replace('__PAGE__',$page,$url)."'>".$page."</a>";
                 }else{
                     break;
                 }
             }else{
                 if($this->totalPages != 1){
-                    $linkPage .= "&nbsp;<span class='current'>".$page."</span>";
+                    $linkPage .= "<span class='current'>".$page."</span>";
                 }
             }
         }


### PR DESCRIPTION
在ie6下有空格 浮动的时候会与异常，没有空格就正常。。
