### PR TITLE
'添加上传错误类型;改进文件后缀获取方式'

### DIFF
--- a/Extend/Library/ORG/Net/UploadFile.class.php
+++ b/Extend/Library/ORG/Net/UploadFile.class.php
@@ -335,6 +335,9 @@ class UploadFile {//类定义开始
             case 7:
                 $this->error = '文件写入失败';
                 break;
+            case 8:
+                $this->error = 'php扩展导致上传终止';
+                break;
             default:
                 $this->error = '未知上传错误！';
         }
@@ -505,8 +508,7 @@ class UploadFile {//类定义开始
      * @return boolean
      */
     private function getExt($filename) {
-        $pathinfo = pathinfo($filename);
-        return $pathinfo['extension'];
+        return pathinfo($filename, PATHINFO_EXTENSION);
     }
 
     /**


### PR DESCRIPTION
上传错误类型中少了一个 PHP5.2.0 添加的错误类型 ：A PHP extension stopped the file upload。

文件后缀获取函数中，如使用 pathinfo($filename, PATHINFO_EXTENSION); 可避免无后缀文件上传时的错误提示，应该是提示 undefined index 等
