### PR TITLE
Update ViewModel.class.php

### DIFF
--- a/Extend/Model/ViewModel.class.php
+++ b/Extend/Model/ViewModel.class.php
@@ -132,7 +132,7 @@ class ViewModel extends Model {
             $orders = explode(',',$order);
             $_order = array();
             foreach ($orders as $order){
-                $array = explode(' ',$order);
+                $array = explode(' ',trim($order));
                 $field   =   $array[0];
                 $sort   =   isset($array[1])?$array[1]:'ASC';
                 // 解析成视图字段


### PR DESCRIPTION
过滤掉排序规则间的空格，比如order('a DESC, b DESC')，在以","做了切分后，若不过滤掉" b DESC"前的空格，导致会导致"b"字段后的" DESC"丢失。
